### PR TITLE
Vectorize reshape operation

### DIFF
--- a/sen_emb.py
+++ b/sen_emb.py
@@ -130,6 +130,8 @@ if __name__ == "__main__":
     with torch.no_grad():
         features = model(**inputs)[1]
 
+    # Reshape features from list of (batch_size, seq_len, hidden_dim) for each hidden state to list
+    # of (num_hidden_states, seq_len, hidden_dim) for each element in the batch.
     all_layer_embedding = list(
         np.array([hidden_state.cpu().numpy() for hidden_state in features]).swapaxes(
             0, 1

--- a/sen_emb.py
+++ b/sen_emb.py
@@ -99,21 +99,18 @@ if __name__ == "__main__":
     batch_input_mask = torch.tensor(features_mask, dtype=torch.long)
     batch = [batch_input_ids.to(device), batch_input_mask.to(device)]
 
-
     inputs = {"input_ids": batch[0], "attention_mask": batch[1]}
     model.zero_grad()
 
     with torch.no_grad():
         features = model(**inputs)[1]
 
-    features = [layer_emb.cpu().numpy() for layer_emb in features]
-    all_layer_embedding = []
-    for i in range(features[0].shape[0]):
-        all_layer_embedding.append(np.array([layer_emb[i] for layer_emb in features]))
+    # Reshape features from list of (batch_size, seq_len, hidden_dim) for each hidden state to list
+    # of (num_hidden_states, seq_len, hidden_dim) for each element in the batch.
+    all_layer_embedding = list(np.array(features).swapaxes(0, 1))
 
     embed_method = utils.generate_embedding(params['embed_method'], features_mask)
     embedding = embed_method.embed(params, all_layer_embedding)
 
-    
     similarity = embedding[0].dot(embedding[1]) / np.linalg.norm(embedding[0]) / np.linalg.norm(embedding[1])
     print('The similarity between these two sentences are (from 0-1):', similarity)

--- a/sen_emb.py
+++ b/sen_emb.py
@@ -132,11 +132,7 @@ if __name__ == "__main__":
 
     # Reshape features from list of (batch_size, seq_len, hidden_dim) for each hidden state to list
     # of (num_hidden_states, seq_len, hidden_dim) for each element in the batch.
-    all_layer_embedding = list(
-        np.array([hidden_state.cpu().numpy() for hidden_state in features]).swapaxes(
-            0, 1
-        )
-    )
+    all_layer_embedding = torch.stack(features).permute(1, 0, 2, 3).cpu().numpy()
 
     embed_method = utils.generate_embedding(params["embed_method"], features_mask)
     embedding = embed_method.embed(params, all_layer_embedding)

--- a/sen_emb.py
+++ b/sen_emb.py
@@ -12,12 +12,12 @@ from transformers import *
 import utils
 
 
-
 # -----------------------------------------------
 def set_seed(args):
     random.seed(args.seed)
     np.random.seed(args.seed)
     torch.manual_seed(args.seed)
+
 
 # -----------------------------------------------
 
@@ -25,46 +25,71 @@ if __name__ == "__main__":
     # -----------------------------------------------
     # Settings
     parser = argparse.ArgumentParser()
-    parser.add_argument("--batch_size", default=64, type=int,
-                        help="batch size for extracting features.")
-    parser.add_argument("--max_seq_length", default=128, type=int,
-                        help="The maximum total input sequence length after tokenization. Sequences longer "
-                             "than this will be truncated, sequences shorter will be padded.")
-    parser.add_argument("--seed", type=int, default=42,
-                        help="random seed for initialization")
-    parser.add_argument("--model_type", type=str, default='bert-base-uncased',
-                        help="Pre-trained language models. (default: 'bert-base-uncased')")
-    parser.add_argument("--embed_method", type=str, default='ave_last_hidden',
-                        help="Choice of method to obtain embeddings (default: 'ave_last_hidden')")
-    parser.add_argument("--context_window_size", type=int, default=2,
-                        help='Topological Embedding Context Window Size (default: 2)')
-    parser.add_argument("--layer_start", type=int, default=4,
-                        help='Starting layer for fusion (default: 4)')
-    parser.add_argument("--tasks", type=str, default='all',
-                        help='choice of tasks to evaluate on') 
+    parser.add_argument(
+        "--batch_size", default=64, type=int, help="batch size for extracting features."
+    )
+    parser.add_argument(
+        "--max_seq_length",
+        default=128,
+        type=int,
+        help="The maximum total input sequence length after tokenization. Sequences longer "
+        "than this will be truncated, sequences shorter will be padded.",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=42, help="random seed for initialization"
+    )
+    parser.add_argument(
+        "--model_type",
+        type=str,
+        default="bert-base-uncased",
+        help="Pre-trained language models. (default: 'bert-base-uncased')",
+    )
+    parser.add_argument(
+        "--embed_method",
+        type=str,
+        default="ave_last_hidden",
+        help="Choice of method to obtain embeddings (default: 'ave_last_hidden')",
+    )
+    parser.add_argument(
+        "--context_window_size",
+        type=int,
+        default=2,
+        help="Topological Embedding Context Window Size (default: 2)",
+    )
+    parser.add_argument(
+        "--layer_start",
+        type=int,
+        default=4,
+        help="Starting layer for fusion (default: 4)",
+    )
+    parser.add_argument(
+        "--tasks", type=str, default="all", help="choice of tasks to evaluate on"
+    )
     args = parser.parse_args()
 
     # -----------------------------------------------
     # Set device
-    torch.cuda.set_device(-1)
-    device = torch.device("cuda", 0)
+    # torch.cuda.set_device(-1)
+    device = torch.device("cpu")
     args.device = device
 
     # -----------------------------------------------
     # Set seed
     set_seed(args)
     # Set up logger
-    logging.basicConfig(format='%(asctime)s : %(message)s', level=logging.DEBUG)
+    logging.basicConfig(format="%(asctime)s : %(message)s", level=logging.DEBUG)
 
     # -----------------------------------------------
     # Set Model
     params = vars(args)
 
-    config = AutoConfig.from_pretrained(params["model_type"], cache_dir='./cache')
+    config = AutoConfig.from_pretrained(params["model_type"], cache_dir="./cache")
     config.output_hidden_states = True
-    tokenizer = AutoTokenizer.from_pretrained(params["model_type"], cache_dir='./cache')
-    model = AutoModelWithLMHead.from_pretrained(params["model_type"], config=config, cache_dir='./cache')
-    model.to(params['device'])
+    tokenizer = AutoTokenizer.from_pretrained(params["model_type"], cache_dir="./cache")
+    model = AutoModelWithLMHead.from_pretrained(
+        params["model_type"], config=config, cache_dir="./cache"
+    )
+    model.to(params["device"])
 
     # -----------------------------------------------
 
@@ -81,16 +106,16 @@ if __name__ == "__main__":
     features_mask = []
     for sent_ids in sentences_index:
         # Truncate if too long
-        if len(sent_ids) > params['max_seq_length']:
-            sent_ids = sent_ids[:params['max_seq_length']]
+        if len(sent_ids) > params["max_seq_length"]:
+            sent_ids = sent_ids[: params["max_seq_length"]]
         sent_mask = [1] * len(sent_ids)
         # Padding
-        padding_length = params['max_seq_length'] - len(sent_ids)
-        sent_ids += ([0] * padding_length)
-        sent_mask += ([0] * padding_length)
+        padding_length = params["max_seq_length"] - len(sent_ids)
+        sent_ids += [0] * padding_length
+        sent_mask += [0] * padding_length
         # Length Check
-        assert len(sent_ids) == params['max_seq_length']
-        assert len(sent_mask) == params['max_seq_length']
+        assert len(sent_ids) == params["max_seq_length"]
+        assert len(sent_mask) == params["max_seq_length"]
 
         features_input_ids.append(sent_ids)
         features_mask.append(sent_mask)
@@ -105,12 +130,18 @@ if __name__ == "__main__":
     with torch.no_grad():
         features = model(**inputs)[1]
 
-    # Reshape features from list of (batch_size, seq_len, hidden_dim) for each hidden state to list
-    # of (num_hidden_states, seq_len, hidden_dim) for each element in the batch.
-    all_layer_embedding = list(np.array(features).swapaxes(0, 1))
+    all_layer_embedding = list(
+        np.array([hidden_state.cpu().numpy() for hidden_state in features]).swapaxes(
+            0, 1
+        )
+    )
 
-    embed_method = utils.generate_embedding(params['embed_method'], features_mask)
+    embed_method = utils.generate_embedding(params["embed_method"], features_mask)
     embedding = embed_method.embed(params, all_layer_embedding)
 
-    similarity = embedding[0].dot(embedding[1]) / np.linalg.norm(embedding[0]) / np.linalg.norm(embedding[1])
-    print('The similarity between these two sentences are (from 0-1):', similarity)
+    similarity = (
+        embedding[0].dot(embedding[1])
+        / np.linalg.norm(embedding[0])
+        / np.linalg.norm(embedding[1])
+    )
+    print("The similarity between these two sentences are (from 0-1):", similarity)

--- a/sen_emb.py
+++ b/sen_emb.py
@@ -69,8 +69,8 @@ if __name__ == "__main__":
 
     # -----------------------------------------------
     # Set device
-    # torch.cuda.set_device(-1)
-    device = torch.device("cpu")
+    torch.cuda.set_device(-1)
+    device = torch.device("cuda", 0)
     args.device = device
 
     # -----------------------------------------------


### PR DESCRIPTION
Hi, thanks for making your code available! I am very interested in trying out the pooling method in [my own sentence encoding project](https://github.com/JohnGiorgi/DeCLUTR).

I got a little hung up on this code in `sent_emb.py`:


https://github.com/BinWang28/SBERT-WK-Sentence-Embedding/blob/ca65d43cbed637f2a7129669110782e9a6f7fe3b/sen_emb.py#L109-L112

It seems this is basically just a reshape operation that swaps the dimension representing the number of layers with the dimension representing the number of sentences. That can be vectorized and replaced with the following one-liner:

```python
all_layer_embedding = torch.stack(features).permute(1, 0, 2, 3).cpu().numpy()
```

This is easier to read and should be slightly faster as it swaps a nested for loop for a series of vectorized operations. I checked that the two approaches are equivalent:

```python

# PROPOSED APPROACH
all_layer_embedding_approach_2 = torch.stack(features).permute(1, 0, 2, 3).cpu().numpy()

# CURRENT APPROACH
features = [layer_emb.cpu().numpy() for layer_emb in features]
all_layer_embedding = []
for i in range(features[0].shape[0]):
    all_layer_embedding.append(np.array([layer_emb[i] for layer_emb in features]))

# CHECK THAT THEY ARE EQUAL
assert np.array_equal(all_layer_embedding, all_layer_embedding_approach_2)
```

This PR just implements that change. I also [black](https://github.com/psf/black) formatted `sent_emb.py` :smile: