### PR TITLE
Vectorize unmask sum computation

### DIFF
--- a/sen_emb.py
+++ b/sen_emb.py
@@ -95,6 +95,8 @@ if __name__ == "__main__":
         features_input_ids.append(sent_ids)
         features_mask.append(sent_mask)
 
+    features_mask = np.array(features_mask)
+
     batch_input_ids = torch.tensor(features_input_ids, dtype=torch.long)
     batch_input_mask = torch.tensor(features_mask, dtype=torch.long)
     batch = [batch_input_ids.to(device), batch_input_mask.to(device)]

--- a/utils.py
+++ b/utils.py
@@ -22,7 +22,7 @@ class generate_embedding():
         """
             Average the output from last layer
         """
-        unmask_num = np.array([sum(mask) for mask in self.masks])
+        unmask_num = np.sum(self.masks, axis=1) - 1 # Not considering the last item
         
         embedding = []
         for i in range(len(unmask_num)):
@@ -40,7 +40,7 @@ class generate_embedding():
         """
             Average the output from last layer
         """
-        unmask_num = np.array([sum(mask) for mask in self.masks])
+        unmask_num = np.sum(self.masks, axis=1) - 1 # Not considering the last item
         
         embedding = []
         for i in range(len(unmask_num)):
@@ -58,7 +58,7 @@ class generate_embedding():
         """
             CLS vector as embedding
         """
-        unmask_num = np.array([sum(mask) for mask in self.masks])
+        unmask_num = np.sum(self.masks, axis=1) - 1 # Not considering the last item
         
         embedding = []
         for i in range(len(unmask_num)):
@@ -75,7 +75,7 @@ class generate_embedding():
         """
             dissecting deep contextualized model
         """
-        unmask_num = np.array([sum(mask) for mask in self.masks]) - 1 # Not considering the last item
+        unmask_num = np.sum(self.masks, axis=1) - 1 # Not considering the last item
         all_layer_embedding = np.array(all_layer_embedding)[:,params['layer_start']:,:,:] # Start from 4th layers output
 
         embedding = []


### PR DESCRIPTION
This PR just vectorizes the computation of `unmask_num`, which is currently computed using list comprehensions and a `sum`

https://github.com/BinWang28/SBERT-WK-Sentence-Embedding/blob/ca65d43cbed637f2a7129669110782e9a6f7fe3b/utils.py#L78

First, we cast `features_mask` to an `array` in `sen_emb.py`, then we replace this list comprehension in `utils.py` with `np.sum`:

```python
unmask_num = np.sum(self.masks, axis=1) - 1 # Not considering the last item
```

This is easier to read and should be slightly faster than the list comprehension it replaces.